### PR TITLE
Fix the Github url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/LibiChai/lcd1602
+module github.com/libi/lcd1602
 
 go 1.12
 


### PR DESCRIPTION
You probably changed your GitHub username, which is why the URL in go.mod isn't working anymore. This PR fixes that.

```
$ go mod tidy
go: finding module for package github.com/libi/lcd1602
go: found github.com/libi/lcd1602 in github.com/libi/lcd1602 v0.0.0-20200524050301-bbc05c3a0dd1
go: github.com/Letsric/pi_radio imports
	github.com/libi/lcd1602: github.com/libi/lcd1602@v0.0.0-20200524050301-bbc05c3a0dd1: parsing go.mod:
	module declares its path as: github.com/LibiChai/lcd1602
	        but was required as: github.com/libi/lcd1602
```